### PR TITLE
fix datetime read according to datasheet

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -53,11 +53,11 @@ where
             .map_err(Error::I2C)?;
         Ok(DateTime {            
             year: decode_bcd(data[6]),
-            month: decode_bcd(data[5]),
-            weekday: decode_bcd(data[4]) & 0x7, //make sure we get only the bits 2:0
-            day: decode_bcd(data[3]),
-            hours: decode_bcd(data[2]),            
-            minutes: decode_bcd(data[1]),
+            month: decode_bcd(data[5] & 0x1f),
+            weekday: decode_bcd(data[4] & 0x07),
+            day: decode_bcd(data[3] & 0x3f),
+            hours: decode_bcd(data[2] & 0x3f),
+            minutes: decode_bcd(data[1] & 0x7f),
             seconds: decode_bcd(data[0]),
         })
     }


### PR DESCRIPTION
Hi !

Thank you for the driver, it helped me a lot !

However I had strange issues while reading time, when seconds were greater or equal to 40 the hours were also added 40.

When reading the datasheet I noticed this sentence: 

> Bit positions labelled as x are not relevant. Bit positions labelled with N should always be written with logic 0; if read they could be either logic 0 or logic 1

So this PR makes sure to ignore the bits which are not relevant before doing the decoding.

<img width="807" alt="Capture d’écran 2021-07-20 à 08 45 28" src="https://user-images.githubusercontent.com/11957179/126274589-04a5b3f1-c9e9-461f-935c-3c7377221b2a.png">
