### PR TITLE
Fix alarm read-back bug.

### DIFF
--- a/src/alarm.rs
+++ b/src/alarm.rs
@@ -135,7 +135,7 @@ where
         self.i2c
             .write_read(DEVICE_ADDRESS, &[Register::MINUTE_ALARM], &mut data)
             .map_err(Error::I2C)?;
-        Ok(decode_bcd(data[0]))
+        Ok(decode_bcd(data[0] & 0b0111_1111))
     }
 
     /// Read the alarm hours setting.
@@ -144,7 +144,7 @@ where
         self.i2c
             .write_read(DEVICE_ADDRESS, &[Register::HOUR_ALARM], &mut data)
             .map_err(Error::I2C)?;
-        Ok(decode_bcd(data[0]))
+        Ok(decode_bcd(data[0] & 0b0011_1111))
     }
 
     /// Read the alarm day setting.
@@ -153,7 +153,7 @@ where
         self.i2c
             .write_read(DEVICE_ADDRESS, &[Register::DAY_ALARM], &mut data)
             .map_err(Error::I2C)?;
-        Ok(decode_bcd(data[0]))
+        Ok(decode_bcd(data[0] & 0b0011_1111))
     }
 
     /// Read the alarm weekday setting.
@@ -162,7 +162,7 @@ where
         self.i2c
             .write_read(DEVICE_ADDRESS, &[Register::WEEKDAY_ALARM], &mut data)
             .map_err(Error::I2C)?;
-        Ok(decode_bcd(data[0]))
+        Ok(decode_bcd(data[0] & 0b0000_0111))
     }
 
     /// Get the alarm flag (if true, alarm event happened).


### PR DESCRIPTION
When reading back previously set alarm data, the required masking was not applied to the returned data before calling `decode_bcd`, resulting in incorrect data being returned.

For more info, see section "8.6 Alarm registers" of the datasheet. 

Upper bits of the alarm registers are used to store the 'enabled' bit, and this must be correctly masked off before decoding the time data values.